### PR TITLE
Fix search bar flickering animations

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -194,11 +194,11 @@ $(function() {
 
 	function getSearch() {
 		if(options.search) {
-			$('.search').fadeIn();
+			$('.search').stop(true).fadeIn();
 			$('#add-search img').attr('src', 'img/check.svg');
 			$('#query').focus();
 		} else {
-			$('.search').fadeOut();
+			$('.search').stop(true).fadeOut();
 			$('#add-search img').attr('src', 'img/uncheck.svg');
 		}
 	}


### PR DESCRIPTION
When the "Google Search" configuration is disabled, when a new tab is being opened, there is a flickering animation of the search bar appearing and then hiding immediately.

This happens because the fadeIn and fadeOut animations go through their full cycle, before and after the options are loaded.

This is especially visible on a dark background, and it is very annoying :)

The fix is to stop all already running animations immediately, once a new animation is ready to be kicked in.