### PR TITLE
Fix clock fadeIn animation

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -75,7 +75,6 @@
 
 
 .clock {
-	display: inline-block;
 	position: relative;
 
 	h1 {


### PR DESCRIPTION
All the `.widget` elements are hidden by default, and they fade in with an animation when a tab is opened. However the class `.clock` overrides this, and therefore the clock is already fully visible when the tab is opened, so no animation for the clock.

It could be by design, but in my opinion with fade it looks better and more consistent. Have a look.